### PR TITLE
Alpha checksum checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Windows isn't posix compatible. You'll need to set up a virtual machine or (if y
    Fedora/RHEL | openssl-devel
    FreeBSD | openssl-devel
 
-
 ## How to compile for GNU/Linux & Homebrew
 ```
 cd helsing

--- a/helsing/Makefile
+++ b/helsing/Makefile
@@ -10,7 +10,7 @@ SRC_DIRS ?= .
 
 CFLAGS := -O2 -Wall -Wextra # compiler flags
 LFLAGS := -Wl,--gc-sections # linker flags
-LIBS := -pthread -l crypto
+LIBS := -pthread -lcrypto
 
 SRCS := $(shell find $(SRC_DIRS) -name *.c)
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)

--- a/helsing/configuration.h
+++ b/helsing/configuration.h
@@ -124,7 +124,7 @@
  * 	   manually.
  */
 
-// NOTE: checkpoint currently doesn't support checksum
+// NOTE: checkpoint checksum support is in alpha
 #define USE_CHECKPOINT false
 #define CHECKPOINT_FILE "a.checkpoint"
 

--- a/helsing/src/binary_tree/bthandle.c
+++ b/helsing/src/binary_tree/bthandle.c
@@ -3,17 +3,17 @@
  * Copyright (c) 2021 Pierro Zachareas
  */
 
-#include <stdlib.h>
-#include <assert.h>
-
 #include "configuration.h"
 
 #ifdef PROCESS_RESULTS
-
+#include <stdlib.h>
+#include <assert.h>
 #include "llhandle.h"
 #include "btnode.h"
 #include "bthandle.h"
+#endif
 
+#ifdef PROCESS_RESULTS
 void bthandle_init(struct bthandle **ptr)
 {
 	struct bthandle *new = NULL;

--- a/helsing/src/binary_tree/bthandle.h
+++ b/helsing/src/binary_tree/bthandle.h
@@ -7,9 +7,13 @@
 #define HELSING_BTHANDLE_H
 
 #include "configuration.h"
+#include "llhandle.h"
 
 #ifdef PROCESS_RESULTS
 #include "btnode.h"
+#endif
+
+#ifdef PROCESS_RESULTS
 struct bthandle
 {
 	struct btnode *node;

--- a/helsing/src/binary_tree/btnode.c
+++ b/helsing/src/binary_tree/btnode.c
@@ -3,15 +3,16 @@
  * Copyright (c) 2021 Pierro Zachareas
  */
 
-#include <stdlib.h>
-#include <assert.h>
-
 #include "configuration.h"
 
 #ifdef PROCESS_RESULTS
-
+#include <stdlib.h>
+#include <assert.h>
 #include "llhandle.h"
 #include "btnode.h"
+#endif
+
+#ifdef PROCESS_RESULTS
 
 void btnode_init(struct btnode **ptr, vamp_t key)
 {

--- a/helsing/src/binary_tree/btnode.h
+++ b/helsing/src/binary_tree/btnode.h
@@ -7,10 +7,9 @@
 #define HELSING_BTNODE_H
 
 #include "configuration.h"
-
-#ifdef PROCESS_RESULTS
 #include "llhandle.h"
-#else
+
+#ifndef PROCESS_RESULTS
 #include <stddef.h> // NULL
 #endif
 
@@ -20,7 +19,7 @@ struct btnode
 	struct btnode *left;
 	struct btnode *right;
 	vamp_t key;
-	length_t height; //Should probably be less than 32
+	length_t height; // Should probably be less than 32
 	uint8_t fang_pairs;
 };
 void btnode_init(struct btnode **ptr, vamp_t key);

--- a/helsing/src/checkpoint/checkpoint.h
+++ b/helsing/src/checkpoint/checkpoint.h
@@ -7,10 +7,15 @@
 #define HELSING_CHECKPOINT_H // safety precaution for the c preprocessor
 
 #include "configuration.h"
+#include "taskboard.h"
 
 #if defined(USE_CHECKPOINT) && USE_CHECKPOINT
 void touch_checkpoint(vamp_t min, vamp_t max);
-void load_checkpoint(vamp_t *min, vamp_t *max, vamp_t *current, vamp_t *count, unsigned char *md_value);
+void load_checkpoint(
+	vamp_t *min,
+	vamp_t *max,
+	vamp_t *current,
+	struct taskboard *progress);
 void save_checkpoint(vamp_t current, vamp_t count, unsigned char *md_value);
 #else /* defined(USE_CHECKPOINT) && USE_CHECKPOINT */
 static inline void touch_checkpoint(
@@ -22,8 +27,7 @@ static inline void load_checkpoint(
 	__attribute__((unused)) vamp_t *min,
 	__attribute__((unused)) vamp_t *max,
 	__attribute__((unused)) vamp_t *current,
-	__attribute__((unused)) vamp_t *count,
-	__attribute__((unused)) unsigned char *md_value)
+	__attribute__((unused)) struct taskboard *progress)
 {
 }
 static inline void save_checkpoint(

--- a/helsing/src/checkpoint/checkpoint.h
+++ b/helsing/src/checkpoint/checkpoint.h
@@ -9,15 +9,15 @@
 #include "configuration.h"
 #include "taskboard.h"
 
-#if defined(USE_CHECKPOINT) && USE_CHECKPOINT
+#if USE_CHECKPOINT
 void touch_checkpoint(vamp_t min, vamp_t max);
 void load_checkpoint(
 	vamp_t *min,
 	vamp_t *max,
 	vamp_t *current,
 	struct taskboard *progress);
-void save_checkpoint(vamp_t current, vamp_t count, unsigned char *md_value);
-#else /* defined(USE_CHECKPOINT) && USE_CHECKPOINT */
+void save_checkpoint(vamp_t current, struct taskboard *progress);
+#else /* USE_CHECKPOINT */
 static inline void touch_checkpoint(
 	__attribute__((unused)) vamp_t min,
 	__attribute__((unused)) vamp_t max)
@@ -32,9 +32,8 @@ static inline void load_checkpoint(
 }
 static inline void save_checkpoint(
 	__attribute__((unused)) vamp_t current,
-	__attribute__((unused)) vamp_t count,
-	__attribute__((unused)) unsigned char *md_value)
+	__attribute__((unused)) struct taskboard *progress)
 {
 }
-#endif /* defined(USE_CHECKPOINT) && USE_CHECKPOINT */
+#endif /* USE_CHECKPOINT */
 #endif /* HELSING_CHECKPOINT_H */

--- a/helsing/src/checkpoint/checkpoint.h
+++ b/helsing/src/checkpoint/checkpoint.h
@@ -22,7 +22,7 @@ static inline void load_checkpoint(
 	__attribute__((unused)) vamp_t *min,
 	__attribute__((unused)) vamp_t *max,
 	__attribute__((unused)) vamp_t *current,
-	__attribute__((unused)) vamp_t *count
+	__attribute__((unused)) vamp_t *count,
 	__attribute__((unused)) unsigned char *md_value)
 {
 }

--- a/helsing/src/checkpoint/checkpoint.h
+++ b/helsing/src/checkpoint/checkpoint.h
@@ -10,8 +10,8 @@
 
 #if defined(USE_CHECKPOINT) && USE_CHECKPOINT
 void touch_checkpoint(vamp_t min, vamp_t max);
-void load_checkpoint(vamp_t *min, vamp_t *max, vamp_t *current, vamp_t *count);
-void save_checkpoint(vamp_t current, vamp_t count);
+void load_checkpoint(vamp_t *min, vamp_t *max, vamp_t *current, vamp_t *count, unsigned char *md_value);
+void save_checkpoint(vamp_t current, vamp_t count, unsigned char *md_value);
 #else /* defined(USE_CHECKPOINT) && USE_CHECKPOINT */
 static inline void touch_checkpoint(
 	__attribute__((unused)) vamp_t min,
@@ -22,12 +22,14 @@ static inline void load_checkpoint(
 	__attribute__((unused)) vamp_t *min,
 	__attribute__((unused)) vamp_t *max,
 	__attribute__((unused)) vamp_t *current,
-	__attribute__((unused)) vamp_t *count)
+	__attribute__((unused)) vamp_t *count
+	__attribute__((unused)) unsigned char *md_value)
 {
 }
 static inline void save_checkpoint(
 	__attribute__((unused)) vamp_t current,
-	__attribute__((unused)) vamp_t count)
+	__attribute__((unused)) vamp_t count,
+	__attribute__((unused)) unsigned char *md_value)
 {
 }
 #endif /* defined(USE_CHECKPOINT) && USE_CHECKPOINT */

--- a/helsing/src/hash/hash.c
+++ b/helsing/src/hash/hash.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Pierro Zachareas
+ */
+
+#include "configuration.h"
+
+#ifdef CHECKSUM_RESULTS
+#include <stdlib.h>
+#include <stdio.h>
+#include <openssl/evp.h>
+#include "hash.h"
+#endif
+
+#ifdef CHECKSUM_RESULTS
+
+void hash_init(struct hash **ptr)
+{
+	struct hash *new = malloc(sizeof(struct hash));
+	if (new == NULL)
+		abort();
+
+	OpenSSL_add_all_digests();
+
+	new->md = EVP_get_digestbyname(DIGEST_NAME);
+	if (!new->md) {
+		printf("Unknown message digest %s\n", DIGEST_NAME);
+		exit(1);
+	}
+
+	new->md_size = EVP_MD_size(new->md);
+	new->md_value = malloc(sizeof(unsigned char) * new->md_size);
+
+	for (int i = 0; i < new->md_size; i++)
+		new->md_value[i] = 0;
+
+	new->mdctx = EVP_MD_CTX_create();
+
+	*ptr = new;	
+}
+
+void hash_free(struct hash *ptr)
+{
+	EVP_MD_CTX_destroy(ptr->mdctx);
+	ptr->mdctx = NULL;
+	free(ptr->mdctx);
+	free(ptr->md_value);
+	free(ptr);
+	EVP_cleanup();
+}
+
+void hash_print(struct hash *ptr)
+{
+	fprintf(stderr, "Digest %s is: ", DIGEST_NAME);
+	for(int i = 0; i < ptr->md_size; i++)
+		fprintf(stderr, "%02x", ptr->md_value[i]);
+	fprintf(stderr, "\n");
+}
+#endif /* CHECKSUM_RESULTS */

--- a/helsing/src/hash/hash.h
+++ b/helsing/src/hash/hash.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Pierro Zachareas
+ */
+
+#ifndef HELSING_HASH_H
+#define HELSING_HASH_H
+
+#include "configuration.h"
+
+#ifdef CHECKSUM_RESULTS
+#include <openssl/evp.h>
+#endif
+
+#ifdef CHECKSUM_RESULTS
+struct hash
+{
+	EVP_MD_CTX *mdctx;
+	const EVP_MD *md;
+	unsigned char *md_value;
+	int md_size;
+};
+void hash_init(struct hash **ptr);
+void hash_free(struct hash *ptr);
+void hash_print(struct hash *ptr);
+#else /* CHECKSUM_RESULTS */
+struct hash
+{
+};
+static inline void hash_init(__attribute__((unused)) struct hash **ptr)
+{
+}
+static inline void hash_free(__attribute__((unused)) struct hash *ptr)
+{
+}
+static inline void hash_print(__attribute__((unused)) struct hash *ptr)
+{
+}
+#endif /* CHECKSUM_RESULTS */
+#endif /* HELSING_HASH_H */

--- a/helsing/src/linked_list/llhandle.c
+++ b/helsing/src/linked_list/llhandle.c
@@ -3,12 +3,14 @@
  * Copyright (c) 2021 Pierro Zachareas
  */
 
-#include <stdlib.h>
-#include <openssl/evp.h>
-
 #include "configuration.h"
+
+#ifdef PROCESS_RESULTS
+#include <stdlib.h>
 #include "llnode.h"
 #include "llhandle.h"
+#include "hash.h"
+#endif
 
 #ifdef PROCESS_RESULTS
 void llhandle_init(struct llhandle **ptr)
@@ -43,13 +45,12 @@ void llhandle_reset(struct llhandle *ptr)
 	ptr->first = NULL;
 	ptr->size = 0;
 }
-
 #endif /* PROCESS_RESULTS */
 
 #if defined(PROCESS_RESULTS) && defined(CHECKSUM_RESULTS)
-void llhandle_checksum(struct llhandle *ptr, EVP_MD_CTX *mdctx, EVP_MD *md, unsigned char *md_value)
+void llhandle_checksum(struct llhandle *ptr, struct hash *checksum)
 {
-	llnode_checksum(ptr->first, mdctx, md, md_value);
+	llnode_checksum(ptr->first, checksum);
 }
 #endif
 

--- a/helsing/src/linked_list/llhandle.c
+++ b/helsing/src/linked_list/llhandle.c
@@ -47,9 +47,9 @@ void llhandle_reset(struct llhandle *ptr)
 #endif /* PROCESS_RESULTS */
 
 #if defined(PROCESS_RESULTS) && defined(CHECKSUM_RESULTS)
-void llhandle_checksum(struct llhandle *ptr, EVP_MD_CTX *mdctx)
+void llhandle_checksum(struct llhandle *ptr, EVP_MD_CTX *mdctx, EVP_MD *md, unsigned char *md_value)
 {
-	llnode_checksum(ptr->first, mdctx);
+	llnode_checksum(ptr->first, mdctx, md, md_value);
 }
 #endif
 

--- a/helsing/src/linked_list/llhandle.h
+++ b/helsing/src/linked_list/llhandle.h
@@ -6,10 +6,12 @@
 #ifndef HELSING_LLHANDLE_H
 #define HELSING_LLHANDLE_H
 
-#include <openssl/evp.h>
-
 #include "configuration.h"
+#include "hash.h"
+
+#ifdef PROCESS_RESULTS
 #include "llnode.h"
+#endif
 
 #ifdef PROCESS_RESULTS
 struct llhandle
@@ -47,13 +49,11 @@ static inline void llhandle_reset(__attribute__((unused)) struct llhandle *ptr)
 #endif /* PROCESS_RESULTS */
 
 #if defined(PROCESS_RESULTS) && defined(CHECKSUM_RESULTS)
-void llhandle_checksum(struct llhandle *ptr, EVP_MD_CTX *mdctx, EVP_MD *md, unsigned char *md_value);
+void llhandle_checksum(struct llhandle *ptr, struct hash *checksum);
 #else
 static inline void llhandle_checksum(
 	__attribute__((unused)) struct llhandle *ptr,
-	__attribute__((unused)) EVP_MD_CTX *mdctx,
-	__attribute__((unused)) EVP_MD *md,
-	__attribute__((unused)) unsigned char *md_value)
+	__attribute__((unused)) struct hash *checksum)
 {
 }
 #endif

--- a/helsing/src/linked_list/llhandle.h
+++ b/helsing/src/linked_list/llhandle.h
@@ -47,11 +47,13 @@ static inline void llhandle_reset(__attribute__((unused)) struct llhandle *ptr)
 #endif /* PROCESS_RESULTS */
 
 #if defined(PROCESS_RESULTS) && defined(CHECKSUM_RESULTS)
-void llhandle_checksum(struct llhandle *ptr, EVP_MD_CTX *mdctx);
+void llhandle_checksum(struct llhandle *ptr, EVP_MD_CTX *mdctx, EVP_MD *md, unsigned char *md_value);
 #else
 static inline void llhandle_checksum(
 	__attribute__((unused)) struct llhandle *ptr,
-	__attribute__((unused)) EVP_MD_CTX *mdctx)
+	__attribute__((unused)) EVP_MD_CTX *mdctx,
+	__attribute__((unused)) EVP_MD *md,
+	__attribute__((unused)) unsigned char *md_value)
 {
 }
 #endif

--- a/helsing/src/linked_list/llnode.c
+++ b/helsing/src/linked_list/llnode.c
@@ -46,7 +46,7 @@ void llnode_free(struct llnode *node)
 #endif /* STORE_RESULTS */
 
 #if defined(STORE_RESULTS) && defined(CHECKSUM_RESULTS)
-void llnode_checksum(struct llnode *node, EVP_MD_CTX *mdctx)
+void llnode_checksum(struct llnode *node, EVP_MD_CTX *mdctx, EVP_MD *md, unsigned char *md_value)
 {
 	for (struct llnode *i = node; i != NULL ; i = i->next) {
 		for (uint16_t j = i->current; j > 0 ; j--) {
@@ -56,7 +56,12 @@ void llnode_checksum(struct llnode *node, EVP_MD_CTX *mdctx)
 			tmp = __builtin_bswap64(tmp);
 			#endif
 
+			EVP_DigestInit_ex(mdctx, md, NULL);
+
+			EVP_DigestUpdate(mdctx, md_value, EVP_MAX_MD_SIZE);
 			EVP_DigestUpdate(mdctx, &tmp, sizeof(tmp));
+
+			EVP_DigestFinal_ex(mdctx, md_value, NULL);
 		}
 	}
 }

--- a/helsing/src/linked_list/llnode.c
+++ b/helsing/src/linked_list/llnode.c
@@ -3,17 +3,22 @@
  * Copyright (c) 2021 Pierro Zachareas
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <openssl/evp.h>
-
 #include "configuration.h"
 
 #ifdef STORE_RESULTS
-
+#include <stdlib.h>
+#include <stdio.h>
 #include "llnode.h"
+#include "hash.h"
+#endif
 
-void llnode_init(struct llnode **ptr, vamp_t value , struct llnode *next)
+#if defined(STORE_RESULTS) && defined(CHECKSUM_RESULTS)
+#include <openssl/evp.h>
+#endif
+
+#ifdef STORE_RESULTS
+
+void llnode_init(struct llnode **ptr, vamp_t value, struct llnode *next)
 {
 	struct llnode *new;
 	if (next != NULL && next->current < LINK_SIZE) {
@@ -46,22 +51,22 @@ void llnode_free(struct llnode *node)
 #endif /* STORE_RESULTS */
 
 #if defined(STORE_RESULTS) && defined(CHECKSUM_RESULTS)
-void llnode_checksum(struct llnode *node, EVP_MD_CTX *mdctx, EVP_MD *md, unsigned char *md_value)
+void llnode_checksum(struct llnode *node, struct hash *checksum)
 {
-	for (struct llnode *i = node; i != NULL ; i = i->next) {
-		for (uint16_t j = i->current; j > 0 ; j--) {
+	for (struct llnode *i = node; i != NULL; i = i->next) {
+		for (uint16_t j = i->current; j > 0; j--) {
 			vamp_t tmp = i->value[j - 1];
 
 			#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 			tmp = __builtin_bswap64(tmp);
 			#endif
 
-			EVP_DigestInit_ex(mdctx, md, NULL);
+			EVP_DigestInit_ex(checksum->mdctx, checksum->md, NULL);
 
-			EVP_DigestUpdate(mdctx, md_value, EVP_MAX_MD_SIZE);
-			EVP_DigestUpdate(mdctx, &tmp, sizeof(tmp));
+			EVP_DigestUpdate(checksum->mdctx, checksum->md_value, checksum->md_size);
+			EVP_DigestUpdate(checksum->mdctx, &tmp, sizeof(tmp));
 
-			EVP_DigestFinal_ex(mdctx, md_value, NULL);
+			EVP_DigestFinal_ex(checksum->mdctx, checksum->md_value, NULL);
 		}
 	}
 }
@@ -70,8 +75,8 @@ void llnode_checksum(struct llnode *node, EVP_MD_CTX *mdctx, EVP_MD *md, unsigne
 #if defined(STORE_RESULTS) && defined(PRINT_RESULTS)
 void llnode_print(struct llnode *node, vamp_t count)
 {
-	for (struct llnode *i = node; i != NULL ; i = i->next) {
-		for (uint16_t j = i->current; j > 0 ; j--) {
+	for (struct llnode *i = node; i != NULL; i = i->next) {
+		for (uint16_t j = i->current; j > 0; j--) {
 			fprintf(stdout, "%llu %llu\n", ++count, i->value[j - 1]);
 			fflush(stdout);
 		}

--- a/helsing/src/linked_list/llnode.h
+++ b/helsing/src/linked_list/llnode.h
@@ -6,10 +6,8 @@
 #ifndef HELSING_LLNODE_H
 #define HELSING_LLNODE_H
 
-#include <stdio.h>
-#include <openssl/evp.h>
-
 #include "configuration.h"
+#include "hash.h"
 
 #ifdef STORE_RESULTS
 struct llnode
@@ -18,7 +16,7 @@ struct llnode
 	uint16_t current;
 	struct llnode *next;
 };
-void llnode_init(struct llnode **ptr, vamp_t value , struct llnode *next);
+void llnode_init(struct llnode **ptr, vamp_t value, struct llnode *next);
 void llnode_free(struct llnode *list);
 #else /* STORE_RESULTS */
 struct llnode
@@ -37,13 +35,11 @@ static inline void llnode_free(
 #endif /* STORE_RESULTS */
 
 #if defined(STORE_RESULTS) && defined(CHECKSUM_RESULTS)
-void llnode_checksum(struct llnode *node, EVP_MD_CTX *mdctx, EVP_MD *md, unsigned char *md_value);
+void llnode_checksum(struct llnode *node, struct hash *checksum);
 #else
 static inline void llnode_checksum(
 	__attribute__((unused)) struct llnode *list,
-	__attribute__((unused)) EVP_MD_CTX *mdctx,
-	__attribute__((unused)) EVP_MD *md,
-	__attribute__((unused)) unsigned char *md_value)
+	__attribute__((unused)) struct hash *checksum)
 {
 }
 #endif

--- a/helsing/src/linked_list/llnode.h
+++ b/helsing/src/linked_list/llnode.h
@@ -37,11 +37,13 @@ static inline void llnode_free(
 #endif /* STORE_RESULTS */
 
 #if defined(STORE_RESULTS) && defined(CHECKSUM_RESULTS)
-void llnode_checksum(struct llnode *list,	EVP_MD_CTX *mdctx);
+void llnode_checksum(struct llnode *node, EVP_MD_CTX *mdctx, EVP_MD *md, unsigned char *md_value);
 #else
 static inline void llnode_checksum(
 	__attribute__((unused)) struct llnode *list,
-	__attribute__((unused)) EVP_MD_CTX *mdctx)
+	__attribute__((unused)) EVP_MD_CTX *mdctx,
+	__attribute__((unused)) EVP_MD *md,
+	__attribute__((unused)) unsigned char *md_value)
 {
 }
 #endif

--- a/helsing/src/main.c
+++ b/helsing/src/main.c
@@ -60,9 +60,8 @@ static vamp_t get_max(vamp_t min, vamp_t max)
 
 static vamp_t get_lmax(vamp_t lmin, vamp_t max)
 {
-	vamp_t lmax;
 	if (length(lmin) < length(vamp_max)) {
-		lmax = pow10v(length(lmin)) - 1;
+		vamp_t lmax = pow10v(length(lmin)) - 1;
 		if (lmax < max)
 			return lmax;
 	}

--- a/helsing/src/main.c
+++ b/helsing/src/main.c
@@ -69,12 +69,12 @@ static vamp_t get_lmax(vamp_t lmin, vamp_t max)
 	return max;
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
 	vamp_t min, max;
 	struct taskboard *progress = taskboard_init();
 
-#if !defined(USE_CHECKPOINT) || !USE_CHECKPOINT
+#if !USE_CHECKPOINT
 	if (argc != 3) {
 		printf("Usage: helsing [min] [max]\n");
 		return 0;

--- a/helsing/src/main.c
+++ b/helsing/src/main.c
@@ -83,7 +83,7 @@ int main(int argc, char* argv[])
 	}
 #else
 	vamp_t count = 0;
-	unsigned char mdtmp[EVP_MAX_MD_SIZE];
+	unsigned char mdtmp[EVP_MAX_MD_SIZE] = {0};
 	if (argc != 1 && argc != 3) {
 		printf("Usage: helsing [min] [max]\n");
 		printf("to recover from %s: helsing\n", CHECKPOINT_FILE);

--- a/helsing/src/main.c
+++ b/helsing/src/main.c
@@ -83,6 +83,7 @@ int main(int argc, char* argv[])
 	}
 #else
 	vamp_t count = 0;
+	unsigned char mdtmp[EVP_MAX_MD_SIZE];
 	if (argc != 1 && argc != 3) {
 		printf("Usage: helsing [min] [max]\n");
 		printf("to recover from %s: helsing\n", CHECKPOINT_FILE);
@@ -90,7 +91,7 @@ int main(int argc, char* argv[])
 	}
 	if (argc == 1) {
 		vamp_t ccurrent;
-		load_checkpoint(&min, &max, &ccurrent, &count);
+		load_checkpoint(&min, &max, &ccurrent, &count, mdtmp);
 		if (ccurrent > min)
 			min = ccurrent + 1;
 	}
@@ -123,6 +124,9 @@ int main(int argc, char* argv[])
 
 #if defined(USE_CHECKPOINT) && USE_CHECKPOINT
 	thhandle->progress->common_count = count;
+
+	for (unsigned int i = 0; i < EVP_MAX_MD_SIZE; i++)
+		thhandle->progress->common_md_value[i] = mdtmp[i];
 #endif
 
 	for (; lmax <= max;) {

--- a/helsing/src/task/task.c
+++ b/helsing/src/task/task.c
@@ -4,12 +4,15 @@
  */
 
 #include <stdlib.h>
-#include <assert.h>
 
 #include "configuration.h"
 #include "task.h"
 #include "llhandle.h"
 #include "vargs.h"
+
+#if defined(PROCESS_RESULTS) && defined(PRINT_RESULTS)
+#include <assert.h>
+#endif
 
 struct task *task_init(vamp_t lmin, vamp_t lmax)
 {

--- a/helsing/src/task/task.h
+++ b/helsing/src/task/task.h
@@ -9,14 +9,12 @@
 #include "configuration.h"
 #include "vargs.h"
 
-#ifdef PROCESS_RESULTS
 #include "llhandle.h"
-#endif
 
 /*
  * task:
  *
- * A task consists of a closed interval [lmin, lmax] and a pointer to a linked 
+ * A task consists of a closed interval [lmin, lmax] and a pointer to a linked
  * list, where the results will be stored.
  */
 

--- a/helsing/src/task/taskboard.c
+++ b/helsing/src/task/taskboard.c
@@ -168,6 +168,22 @@ void taskboard_cleanup(struct taskboard *ptr)
 	}
 }
 
+void taskboard_print_results(struct taskboard *ptr)
+{
+#if defined COUNT_RESULTS ||  defined DUMP_RESULTS
+	fprintf(stderr, "Found: %llu valid fang pairs.\n", ptr->common_count);
+#else
+	fprintf(stderr, "Found: %llu vampire numbers.\n",  ptr->common_count);
+#endif
+
+#ifdef CHECKSUM_RESULTS
+	fprintf(stderr, "Digest %s is: ", DIGEST_NAME);
+	for(unsigned int i = 0; i < EVP_MAX_MD_SIZE; i++)
+		fprintf(stderr, "%02x", ptr->common_md_value[i]);
+	fprintf(stderr, "\n");
+#endif
+}
+
 #if defined(PROCESS_RESULTS) && defined(PRINT_RESULTS)
 
 void taskboard_print(struct taskboard *ptr)

--- a/helsing/src/task/taskboard.h
+++ b/helsing/src/task/taskboard.h
@@ -6,10 +6,9 @@
 #ifndef HELSING_TASKBOARD_H
 #define HELSING_TASKBOARD_H
 
-#include <openssl/evp.h>
-
 #include "configuration.h"
 #include "task.h"
+#include "hash.h"
 
 struct taskboard
 {
@@ -18,10 +17,8 @@ struct taskboard
 	vamp_t todo; // First task that hasn't been accepted.
 	vamp_t done; // Last task that's completed, but isn't yet processed. (print, hash, checksum...)
 	fang_t fmax;
-	EVP_MD_CTX *common_mdctx;
-	EVP_MD *common_md;
-	unsigned char common_md_value[EVP_MAX_MD_SIZE];
 	vamp_t common_count;
+	struct hash *checksum;
 };
 
 struct taskboard *taskboard_init();
@@ -41,7 +38,7 @@ static inline void taskboard_print(__attribute__((unused)) struct taskboard *ptr
 #endif /* defined(PROCESS_RESULTS) && defined(PRINT_RESULTS) */
 
 #if DISPLAY_PROGRESS
-void taskboard_progress( struct taskboard *ptr);
+void taskboard_progress(struct taskboard *ptr);
 #else /* DISPLAY_PROGRESS */
 static inline void taskboard_progress(__attribute__((unused)) struct taskboard *ptr)
 {

--- a/helsing/src/task/taskboard.h
+++ b/helsing/src/task/taskboard.h
@@ -30,6 +30,7 @@ void taskboard_set(struct taskboard *ptr, vamp_t lmin, vamp_t lmax);
 void taskboard_reset(struct taskboard *ptr);
 struct task *taskboard_get_task(struct taskboard *ptr);
 void taskboard_cleanup(struct taskboard *ptr);
+void taskboard_print_results(struct taskboard *ptr);
 
 #if defined(PROCESS_RESULTS) && defined(PRINT_RESULTS)
 void taskboard_print(struct taskboard *ptr);

--- a/helsing/src/task/taskboard.h
+++ b/helsing/src/task/taskboard.h
@@ -19,6 +19,8 @@ struct taskboard
 	vamp_t done; // Last task that's completed, but isn't yet processed. (print, hash, checksum...)
 	fang_t fmax;
 	EVP_MD_CTX *common_mdctx;
+	EVP_MD *common_md;
+	unsigned char common_md_value[EVP_MAX_MD_SIZE];
 	vamp_t common_count;
 };
 

--- a/helsing/src/thread/targs.c
+++ b/helsing/src/thread/targs.c
@@ -6,13 +6,13 @@
 #include <stdlib.h>
 #include <pthread.h>
 
-#if MEASURE_RUNTIME
-#include <time.h>
-#endif
-
 #include "configuration.h"
 #include "cache.h"
 #include "targs.h"
+
+#if MEASURE_RUNTIME
+#include <time.h>
+#endif
 
 struct targs_t *targs_t_init(
 	pthread_mutex_t *read,

--- a/helsing/src/thread/targs.h
+++ b/helsing/src/thread/targs.h
@@ -8,13 +8,13 @@
 
 #include <pthread.h>
 
-#if MEASURE_RUNTIME
-#include <time.h>
-#endif
-
 #include "configuration.h"
 #include "taskboard.h"
 #include "cache.h"
+
+#if MEASURE_RUNTIME
+#include <time.h>
+#endif
 
 struct targs_t
 {

--- a/helsing/src/thread/targs_handle.c
+++ b/helsing/src/thread/targs_handle.c
@@ -15,13 +15,13 @@
 #include "targs.h"
 #include "targs_handle.h"
 
-struct targs_handle *targs_handle_init(vamp_t max)
+struct targs_handle *targs_handle_init(vamp_t max, struct taskboard *progress)
 {
 	struct targs_handle *new = malloc(sizeof(struct targs_handle));
 	if (new == NULL)
 		abort();
 
-	new->progress = taskboard_init();
+	new->progress = progress;
 	cache_init(&(new->digptr), max);
 
 	new->read = malloc(sizeof(pthread_mutex_t));
@@ -64,18 +64,7 @@ void targs_handle_print(struct targs_handle *ptr)
 	fprintf(stderr, "\nFang search took: %.2lf s, average: %.2lf s\n", total_time, total_time / THREADS);
 #endif
 
-#if defined COUNT_RESULTS ||  defined DUMP_RESULTS
-	fprintf(stderr, "Found: %llu valid fang pairs.\n", ptr->progress->common_count);
-#else
-	fprintf(stderr, "Found: %llu vampire numbers.\n",  ptr->progress->common_count);
-#endif
-
-#ifdef CHECKSUM_RESULTS
-	printf("Digest %s is: ", DIGEST_NAME);
-	for(unsigned int i = 0; i < EVP_MAX_MD_SIZE; i++)
-		printf("%02x", ptr->progress->common_md_value[i]);
-	printf("\n");
-#endif
+	taskboard_print_results(ptr->progress);
 }
 
 void *thread_worker(void *void_args)

--- a/helsing/src/thread/targs_handle.c
+++ b/helsing/src/thread/targs_handle.c
@@ -71,16 +71,9 @@ void targs_handle_print(struct targs_handle *ptr)
 #endif
 
 #ifdef CHECKSUM_RESULTS
-	unsigned char md_value[EVP_MAX_MD_SIZE];
-	unsigned int md_len;
-
-	EVP_DigestFinal_ex(ptr->progress->common_mdctx, md_value, &md_len);
-	EVP_MD_CTX_destroy(ptr->progress->common_mdctx);
-	ptr->progress->common_mdctx = NULL;
-
 	printf("Digest %s is: ", DIGEST_NAME);
-	for(unsigned int i = 0; i < md_len; i++)
-		printf("%02x", md_value[i]);
+	for(unsigned int i = 0; i < EVP_MAX_MD_SIZE; i++)
+		printf("%02x", ptr->progress->common_md_value[i]);
 	printf("\n");
 #endif
 }

--- a/helsing/src/thread/targs_handle.h
+++ b/helsing/src/thread/targs_handle.h
@@ -22,7 +22,7 @@ struct targs_handle
 	pthread_mutex_t *write;
 };
 
-struct targs_handle *targs_handle_init(vamp_t max);
+struct targs_handle *targs_handle_init(vamp_t max, struct taskboard *progress);
 void targs_handle_free(struct targs_handle *ptr);
 void targs_handle_print(struct targs_handle *ptr);
 

--- a/helsing/src/vampire/cache.c
+++ b/helsing/src/vampire/cache.c
@@ -4,11 +4,13 @@
  * Copyright (c) 2021 Pierro Zachareas
  */
 
-#include <stdlib.h>
-
 #include "configuration.h"
+
+#if CACHE
+#include <stdlib.h>
 #include "helper.h"
 #include "cache.h"
+#endif
 
 #if CACHE
 

--- a/helsing/src/vampire/vargs.h
+++ b/helsing/src/vampire/vargs.h
@@ -11,7 +11,7 @@
 #include "bthandle.h"
 #include "cache.h"
 
-struct vargs	/* Vampire arguments */
+struct vargs /* Vampire arguments */
 {
 	struct cache *digptr;
 	struct bthandle *thandle;


### PR DESCRIPTION
performance impact:
-output binary file size seems to be smaller
-verbose level 3 takes +6% more time for lower digit ranges. Higher digit ranges seem unaffected.
-all other verbose levels seem unaffected