### PR TITLE
Add CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build*
+cmake-build*
 .idea
 helsing/helsing

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build*
+.idea
+helsing/helsing

--- a/helsing/.gitignore
+++ b/helsing/.gitignore
@@ -1,3 +1,0 @@
-build*
-helsing
-.idea

--- a/helsing/.gitignore
+++ b/helsing/.gitignore
@@ -1,0 +1,3 @@
+build*
+helsing
+.idea

--- a/helsing/CMakeLists.txt
+++ b/helsing/CMakeLists.txt
@@ -4,6 +4,9 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING "Flags used by the compiler during release builds." FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING "Flags used by the compiler during release builds." FORCE)
+
 project(helsing VERSION 1.1.1)
 
 option(ENABLE_LTO "enable link time optimization" OFF)
@@ -19,10 +22,9 @@ if(ENABLE_LTO)
     endif()
 endif()
 
-#add_compile_options(-Wall -Wextra)
+add_compile_options(-Wall -Wextra)
 add_compile_options(-march=native)
 
-string(REPLACE "-O3" "-O2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
 find_package(Threads)
 find_package(OpenSSL)

--- a/helsing/CMakeLists.txt
+++ b/helsing/CMakeLists.txt
@@ -1,30 +1,33 @@
 cmake_minimum_required(VERSION 3.13)
 
-if(NOT CMAKE_BUILD_TYPE)
+if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
-endif()
+endif ()
 
-set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING "Flags used by the compiler during release builds." FORCE)
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING "Flags used by the compiler during release builds." FORCE)
+set(CMAKE_C_FLAGS_RELEASE "-O2" CACHE STRING "Flags used by the compiler during release builds." FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "-O2" CACHE STRING "Flags used by the compiler during release builds." FORCE)
+set(CMAKE_C_FLAGS_MINSIZEREL "-Os" CACHE STRING "Flags used by the compiler during release builds." FORCE)
+set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os" CACHE STRING "Flags used by the compiler during release builds." FORCE)
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g" CACHE STRING "Flags used by the compiler during release builds." FORCE)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g" CACHE STRING "Flags used by the compiler during release builds." FORCE)
 
 project(helsing VERSION 1.1.1)
 
 option(ENABLE_LTO "enable link time optimization" OFF)
 
-if(ENABLE_LTO)
+if (ENABLE_LTO)
     include(CheckIPOSupported)
     cmake_policy(SET CMP0069 NEW)
     check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_SUPPORT_OUTPUT)
-    if(IPO_SUPPORTED)
+    if (IPO_SUPPORTED)
         set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-    else()
+    else ()
         message(WARNING "LTO is not supported: ${IPO_SUPPORT_OUTPUT}")
-    endif()
-endif()
+    endif ()
+endif ()
 
 add_compile_options(-Wall -Wextra)
 add_compile_options(-march=native)
-
 
 find_package(Threads)
 find_package(OpenSSL)

--- a/helsing/CMakeLists.txt
+++ b/helsing/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.13)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+project(helsing VERSION 1.1.1)
+
+option(ENABLE_LTO "enable link time optimization" OFF)
+
+if(ENABLE_LTO)
+    include(CheckIPOSupported)
+    cmake_policy(SET CMP0069 NEW)
+    check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_SUPPORT_OUTPUT)
+    if(IPO_SUPPORTED)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+    else()
+        message(WARNING "LTO is not supported: ${IPO_SUPPORT_OUTPUT}")
+    endif()
+endif()
+
+#add_compile_options(-Wall -Wextra)
+add_compile_options(-march=native)
+
+string(REPLACE "-O3" "-O2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+
+find_package(Threads)
+find_package(OpenSSL)
+
+add_executable(helsing
+    src/array/array.c
+    src/checkpoint/checkpoint.c
+    src/hash/hash.c
+    src/helper/helper.c
+    src/interval/interval.c
+    src/linked_list/llnode.c
+    src/main.c
+    src/options/options.c
+    src/task/task.c
+    src/task/taskboard.c
+    src/thread/targs.c
+    src/thread/targs_handle.c
+    src/vampire/cache.c
+    src/vampire/vargs.c
+    )
+target_include_directories(helsing PRIVATE
+    .
+    src/array
+    src/checkpoint
+    src/hash
+    src/helper
+    src/interval
+    src/linked_list
+    src/options
+    src/task
+    src/thread
+    src/vampire
+    )
+target_link_libraries(helsing
+    m
+    Threads::Threads
+    OpenSSL::Crypto
+    )


### PR DESCRIPTION
This PR adds a `CMakeLists.txt`, to support building with CMake.

What I'm stumped on here is configuration options - the whole of `configuration.h` and possibly `configuration_adv.h`. You advise changing the file directly - and sure, it will work just fine with CMake as well. But the Proper CMake Way (tm) is to provide those options as CMakeLists configuration variables and generate `configuration.h` from those. Maintaining two version of that file is an obvious no-go. There's some optional special handling for defines, but CMake's [configure_file[(https://cmake.org/cmake/help/latest/command/configure_file.html) basically boils down to string replacement. It should be possible to hack something with sed or awk to emulate this behavior on non-CMake builds, but it's probably not worth the hasle.