### PR TITLE
Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 build*
 cmake-build*
+CMakeFiles*
+cmake_install.cmake
+CMakeCache.txt
 .idea
 helsing/helsing

--- a/README.md
+++ b/README.md
@@ -239,8 +239,6 @@ $ ./helsing --buildconf
     MEASURE_RUNTIME=false
     CACHE=true
     COMPARISON_BITS=64
-    DEDICATED_BITFIELDS=false
-    USE_PDEP=false
     BASE=10
     MAX_TASK_SIZE=99999999999
     USE_CHECKPOINT=false

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Helsing is a command-line program that scans intervals for vampire numbers.
 The default algorithm has a time complexity of $O(n)$ and a space complexity of
 $O(\sqrt{n})$.
 
-In *helsing/configuration.h* you can select the algorithm implementation and
-tune it, adjust verbosity, change the numeral base system, set a minimum fang
-pairs filter, and enable resume from checkpoint.
+In *helsing/configuration.h* you can toggle the algorithms and tune them,
+adjust verbosity, change the numeral base system, set a minimum fang pairs
+filter, and enable resume from checkpoint.
 Be sure to read the documentation.
 
 ## Windows Preparation
@@ -237,7 +237,8 @@ $ ./helsing --buildconf
     VERBOSE_LEVEL=2
     MIN_FANG_PAIRS=1
     MEASURE_RUNTIME=false
-    CACHE=true
+    ALG_NORMAL=false
+    ALG_CACHE=true
     COMPARISON_BITS=64
     BASE=10
     MAX_TASK_SIZE=99999999999

--- a/helsing/CMakeLists.txt
+++ b/helsing/CMakeLists.txt
@@ -29,6 +29,35 @@ endif ()
 add_compile_options(-Wall -Wextra)
 add_compile_options(-march=native)
 
+# re-run cmake if the configurtation files change
+
+function(watch)
+    set_property(
+            DIRECTORY
+            APPEND
+            PROPERTY CMAKE_CONFIGURE_DEPENDS ${ARGV}
+    )
+endfunction()
+
+watch("${CMAKE_CURRENT_SOURCE_DIR}/configuration.h")
+watch("${CMAKE_CURRENT_SOURCE_DIR}/configuration_adv.h")
+
+# Detect if OpenSSL is required
+
+execute_process(
+    COMMAND sh -c "${CMAKE_C_COMPILER} -dM -E -I \"${CMAKE_CURRENT_SOURCE_DIR}configuration.h\" \"${CMAKE_CURRENT_SOURCE_DIR}/configuration_adv.h\" | grep -q \"CHECKSUM_RESULTS\""
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE CHECKSUM
+    )
+
+if (CHECKSUM EQUAL "0")
+    message(STATUS "OpenSSL required")
+    set(HELSING_OPENSSL_CRYPTO "OpenSSL::Crypto")
+else()
+    message(STATUS "OpenSSL optional")
+    set(HELSING_OPENSSL_CRYPTO "")
+endif()
+
 find_package(Threads)
 find_package(OpenSSL)
 
@@ -64,5 +93,5 @@ target_include_directories(helsing PRIVATE
 target_link_libraries(helsing
     m
     Threads::Threads
-    OpenSSL::Crypto
+    ${HELSING_OPENSSL_CRYPTO}
     )

--- a/helsing/Makefile
+++ b/helsing/Makefile
@@ -25,11 +25,11 @@ OPTIMIZE := -O2
 LFLAGS := # -Wl,--gc-sections
 LIBS := -lpthread -lm $(shell if $(CC) -dM -E -I$(SRC_DIRS)/configuration.h $(SRC_DIRS)/configuration_adv.h | grep -q "CHECKSUM_RESULTS"; then echo "-lcrypto"; fi)
 
-SRCS := $(shell find $(SRC_DIRS) -name *.c)
+SRCS := $(shell find $(SRC_DIRS) -name *.c | sort)
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
-INC_DIRS := $(shell find $(SRC_DIRS) -type d)
+INC_DIRS := $(shell find $(SRC_DIRS) -type d | sort)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
 CPPFLAGS ?= $(INC_FLAGS) -MMD -MP

--- a/helsing/Makefile
+++ b/helsing/Makefile
@@ -18,7 +18,7 @@ CC := $(shell \
 WARNINGS := -Wall -Wextra
 DEBUG := # -fsanitize=thread
 
-OPTIMIZE := -O2 -march=native
+OPTIMIZE := -O2
 # If the code is underperforming, try recompiling it with some of these flags:
 # -falign-functions=32 -falign-loops=32 -march=native -mtune=native
 

--- a/helsing/configuration.h
+++ b/helsing/configuration.h
@@ -27,7 +27,21 @@
 #define MEASURE_RUNTIME false
 
 /*
- * CACHE:
+ * ALGORITHMS:
+ *
+ * The included algorithms:
+ * 1) normal
+ * 2) cache
+ *
+ * They can be toggled individually.
+ * When more than one algorithms are enabled, the results have to satisfy only
+ * one of them.
+ */
+
+#define ALG_NORMAL false
+
+/*
+ * ALG_CACHE:
  *
  * 	This code was originally written by Jens Kruse Andersen and is included
  * with their permission. Adjustments were made to improve runtime, memory
@@ -73,18 +87,18 @@
  *
  * 	*Based on some of my testing in base-10. Your mileage may vary.
  *
- * CACHE Options:
+ * ALG_CACHE Options:
  *
  * 1) COMPARISON_BITS:
  * 	The #bits used for the vampire check. It can be set to 64(default) or 32.
- * 	Setting COMPARISON_BITS to 32 will half the CACHE size and use 32-bit
+ * 	Setting COMPARISON_BITS to 32 will half the ALG_CACHE size and use 32-bit
  * 	variables.
  *
  * These options adjust the space of solvable intervals to avoid
  * false-positives.
  */
 
-#define CACHE true
+#define ALG_CACHE true
 #define COMPARISON_BITS 64
 
 /*
@@ -94,7 +108,7 @@
  * checking algorithm.
  *
  * For bases above 255 adjust digit_t accordingly.
- * If 2^(ELEMENT_BITS/(BASE-1)) < ELEMENT_BITS/log2(BASE-1), then disable CACHE.
+ * If 2^(ELEMENT_BITS/(BASE-1)) < ELEMENT_BITS/log2(BASE-1), then disable ALG_CACHE.
  */
 
 #define BASE 10

--- a/helsing/configuration.h
+++ b/helsing/configuration.h
@@ -80,22 +80,12 @@
  * 	Setting COMPARISON_BITS to 32 will half the CACHE size and use 32-bit
  * 	variables.
  *
- * 2) DEDICATED_BITFIELDS:
- * 	This allows the use of bitshift operations instead of multiplication in
- * 	the function set_dig().
- *
- * 3) PDEP:
- * 	Use DEDICATED_BITFIELDS and half the CACHE size, then use pdep to expand
- * 	from 32 to 64 bits.
- *
  * These options adjust the space of solvable intervals to avoid
  * false-positives.
  */
 
 #define CACHE true
 #define COMPARISON_BITS 64
-#define DEDICATED_BITFIELDS false
-#define USE_PDEP false
 
 /*
  * BASE:

--- a/helsing/configuration_adv.h
+++ b/helsing/configuration_adv.h
@@ -11,19 +11,8 @@
 #include <time.h>
 #include "configuration.h"
 
-#if USE_PDEP && COMPARISON_BITS == 64
-	#define ELEMENT_BITS 32
-	#undef DEDICATED_BITFIELDS
-	#define DEDICATED_BITFIELDS true
-#else
-	#define ELEMENT_BITS COMPARISON_BITS
-#endif
-
-#if DEDICATED_BITFIELDS
-	#define ACTIVE_BITS (ELEMENT_BITS / (BASE - 1)) * (BASE - 1)
-#else
-	#define ACTIVE_BITS ELEMENT_BITS
-#endif
+#define ELEMENT_BITS COMPARISON_BITS
+#define ACTIVE_BITS ELEMENT_BITS
 
 /*
  * The following typedefs are used to explicate intent.
@@ -89,14 +78,6 @@ typedef uint8_t length_t;
 
 #if (BASE < 2)
 #error BASE must be larger than 1
-#endif
-
-#if (USE_PDEP && COMPARISON_BITS != 64)
-#error PDEP requires COMPARISON_BITS 64
-#endif
-
-#if defined(DEDICATED_BITFIELDS) && (BASE > ELEMENT_BITS)
-#error BASE is too large
 #endif
 
 #if SAFETY_CHECKS

--- a/helsing/src/helper/helper.c
+++ b/helsing/src/helper/helper.c
@@ -72,26 +72,3 @@ vamp_t div_roof(vamp_t x, vamp_t y)
 {
 	return (x/y + !!(x%y));
 }
-
-/*
- * partition3:
- *
- * partition x into 3 integers so that:
- * x <= 2 * A + B
- * and return A.
- */
-
-length_t partition3(length_t x)
-{
-	length_t ret = x / 3;
-
-	// adjust for product iterator
-	length_t n = x / 2;
-	if (ret < n + 1 - ret)
-		ret = n + 1 - ret;
-
-	if (ret == 0)
-		ret = 1;
-
-	return ret;
-}

--- a/helsing/src/helper/helper.c
+++ b/helsing/src/helper/helper.c
@@ -15,6 +15,7 @@ void no_args() {};
 /*
  * willoverflow:
  * Checks if (10 * x + digit) will overflow, without causing and overflow.
+ * Should only be used for input checking, where the numeral base is 10.
  */
 bool willoverflow(vamp_t x, vamp_t limit, digit_t digit)
 {

--- a/helsing/src/helper/helper.h
+++ b/helsing/src/helper/helper.h
@@ -12,11 +12,11 @@
 
 void no_args();
 bool willoverflow(vamp_t x, vamp_t limit, digit_t digit);
-length_t length(vamp_t x);
-vamp_t pow_v(length_t exponent);
+__attribute__((const)) length_t length(vamp_t x);
+__attribute__((const)) vamp_t pow_v(length_t exponent);
 vamp_t get_min(vamp_t min, vamp_t max);
 vamp_t get_max(vamp_t min, vamp_t max);
-vamp_t div_roof(vamp_t x, vamp_t y);
-length_t partition3(length_t x);
+__attribute__((const)) vamp_t div_roof(vamp_t x, vamp_t y);
+__attribute__((const)) length_t partition3(length_t x);
 
 #endif /* HELPER_HELSING */

--- a/helsing/src/helper/helper.h
+++ b/helsing/src/helper/helper.h
@@ -17,6 +17,5 @@ __attribute__((const)) vamp_t pow_v(length_t exponent);
 vamp_t get_min(vamp_t min, vamp_t max);
 vamp_t get_max(vamp_t min, vamp_t max);
 __attribute__((const)) vamp_t div_roof(vamp_t x, vamp_t y);
-__attribute__((const)) length_t partition3(length_t x);
 
 #endif /* HELPER_HELSING */

--- a/helsing/src/interval/interval.c
+++ b/helsing/src/interval/interval.c
@@ -29,12 +29,10 @@ int interval_set(struct interval_t *ptr, vamp_t min, vamp_t max)
 
 	if (cache_ovf_chk(ptr->max)) {
 		fprintf(stderr, "WARNING: the code might produce false positives, ");
-		if (COMPARISON_BITS == 32) {
+		if (COMPARISON_BITS == 32)
 			fprintf(stderr, "please set COMPARISON_BITS to 64.\n");
-		}
-		else {
-			fprintf(stderr, "please set CACHE to false.\n");
-		}
+		else
+			fprintf(stderr, "please set ALG_CACHE to false.\n");
 		rc = 1;
 		goto out;
 	}

--- a/helsing/src/interval/interval.c
+++ b/helsing/src/interval/interval.c
@@ -29,13 +29,7 @@ int interval_set(struct interval_t *ptr, vamp_t min, vamp_t max)
 
 	if (cache_ovf_chk(ptr->max)) {
 		fprintf(stderr, "WARNING: the code might produce false positives, ");
-		if (USE_PDEP) {
-			fprintf(stderr, "please set USE_PDEP to false.\n");
-		}
-		else if (DEDICATED_BITFIELDS) {
-			fprintf(stderr, "please set DEDICATED_BITFIELDS to false.\n");
-		}
-		else if (COMPARISON_BITS == 32) {
+		if (COMPARISON_BITS == 32) {
 			fprintf(stderr, "please set COMPARISON_BITS to 64.\n");
 		}
 		else {

--- a/helsing/src/options/options.c
+++ b/helsing/src/options/options.c
@@ -26,11 +26,8 @@ static void buildconf()
 		printf("    MIN_FANG_PAIRS=%d\n", MIN_FANG_PAIRS);
 	printf("    MEASURE_RUNTIME=%s\n", (MEASURE_RUNTIME ? "true" : "false"));
 	printf("    CACHE=%s\n", (CACHE ? "true" : "false"));
-	if (CACHE) {
+	if (CACHE)
 		printf("    COMPARISON_BITS=%d\n", COMPARISON_BITS);
-		printf("    DEDICATED_BITFIELDS=%s\n", (DEDICATED_BITFIELDS ? "true" : "false"));
-		printf("    USE_PDEP=%s\n", (USE_PDEP ? "true" : "false"));
-	}
 	printf("    BASE=%d\n", BASE);
 	printf("    MAX_TASK_SIZE=%llu\n", MAX_TASK_SIZE);
 	printf("    USE_CHECKPOINT=%s\n", (USE_CHECKPOINT ? "true" : "false"));

--- a/helsing/src/options/options.c
+++ b/helsing/src/options/options.c
@@ -25,8 +25,9 @@ static void buildconf()
 	if (VERBOSE_LEVEL > 1)
 		printf("    MIN_FANG_PAIRS=%d\n", MIN_FANG_PAIRS);
 	printf("    MEASURE_RUNTIME=%s\n", (MEASURE_RUNTIME ? "true" : "false"));
-	printf("    CACHE=%s\n", (CACHE ? "true" : "false"));
-	if (CACHE)
+	printf("    ALG_NORMAL=%s\n", (ALG_NORMAL ? "true" : "false"));
+	printf("    ALG_CACHE=%s\n", (ALG_CACHE ? "true" : "false"));
+	if (ALG_CACHE)
 		printf("    COMPARISON_BITS=%d\n", COMPARISON_BITS);
 	printf("    BASE=%d\n", BASE);
 	printf("    MAX_TASK_SIZE=%llu\n", MAX_TASK_SIZE);

--- a/helsing/src/vampire/cache.c
+++ b/helsing/src/vampire/cache.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
  * Copyright (c) 2012 Jens Kruse Andersen
- * Copyright (c) 2021-2022 Pierro Zachareas
+ * Copyright (c) 2021-2023 Pierro Zachareas
  */
 
 #include "configuration.h"
@@ -47,26 +47,26 @@ void cache_new(struct cache **ptr, vamp_t min, vamp_t max)
 	length_t cs = 0;
 	length_t i = length(min);
 
-	struct partdata_t data;
-	struct partdata_const_t data_const = {
+	struct partdata_all_t data;
+	struct partdata_constant_t data_constant = {
 		.idx_n = false
 	};
-	struct partdata_global_t data_glob = {
+	struct partdata_global_t data_global = {
 		.multiplicand_parts = 2,
 		.product_parts = 3
 	};
 
 	do {
-		data_glob.multiplicand_length = div_roof(i, 2);
-		data_glob.product_length = i;
+		data_global.multiplicand_length = div_roof(i, 2);
+		data_global.product_length = i;
 
-		data_glob.multiplicand_iterator = length(BASE - 1);
-		data_glob.product_iterator = data_glob.multiplicand_length + length(BASE - 1);
+		data_global.multiplicand_iterator = length(BASE - 1);
+		data_global.product_iterator = data_global.multiplicand_length + length(BASE - 1);
 
-		data_const.idx_n = false;
-		length_t part_A = part_scsg_3(data, data_const, data_glob);
-		data_const.idx_n = true;
-		length_t part_B = part_scsg_3(data, data_const, data_glob);
+		data_constant.idx_n = false;
+		length_t part_A = part_scsg_3(data_constant, data_global);
+		data_constant.idx_n = true;
+		length_t part_B = part_scsg_3(data_constant, data_global);
 		if (part_A > cs)
 			cs = part_A;
 		if (part_B > cs)
@@ -123,19 +123,18 @@ bool cache_ovf_chk(vamp_t max)
  */
 
 length_t part_scsg_3(
-	__attribute__((unused)) struct partdata_t data,
-	struct partdata_const_t data_const,
-	struct partdata_global_t data_glob)
+	struct partdata_constant_t data_constant,
+	struct partdata_global_t data_global)
 {
-	length_t x = data_glob.product_length;
+	length_t x = data_global.product_length;
 
 	length_t B = x;
 	length_t multiplicand_maxB = 0;
-	if (data_glob.multiplicand_length > data_glob.multiplicand_iterator)
-		multiplicand_maxB = data_glob.multiplicand_length - data_glob.multiplicand_iterator;
+	if (data_global.multiplicand_length > data_global.multiplicand_iterator)
+		multiplicand_maxB = data_global.multiplicand_length - data_global.multiplicand_iterator;
 	length_t product_maxB = 0;
-	if (data_glob.product_length > data_glob.product_iterator)
-		product_maxB = data_glob.product_length - data_glob.product_iterator;
+	if (data_global.product_length > data_global.product_iterator)
+		product_maxB = data_global.product_length - data_global.product_iterator;
 
 	if (B > multiplicand_maxB)
 		B = multiplicand_maxB;
@@ -143,9 +142,9 @@ length_t part_scsg_3(
 	if (B > product_maxB)
 		B = product_maxB;
 
-	length_t max = data_glob.multiplicand_parts;
-	if (max < data_glob.product_parts)
-		max = data_glob.product_parts;
+	length_t max = data_global.multiplicand_parts;
+	if (max < data_global.product_parts)
+		max = data_global.product_parts;
 
 	length_t remainder = (x - B) % (max - 1);
 	if (remainder > 0) {
@@ -155,7 +154,7 @@ length_t part_scsg_3(
 		else
 			x += adjust;
 	}
-	if (data_const.idx_n)
+	if (data_constant.idx_n)
 		return B;
 
 	length_t A = (x - B) / 2;

--- a/helsing/src/vampire/cache.c
+++ b/helsing/src/vampire/cache.c
@@ -18,14 +18,7 @@
 #if CACHE
 
 #define BITS_PER_NUMERAL(bits) ((double)(bits))/(double)(BASE - 1)
-
-#if DEDICATED_BITFIELDS
-#define BITS_PER_NUMERAL2(bits) floor(BITS_PER_NUMERAL(bits))
-#else
-#define BITS_PER_NUMERAL2(bits) BITS_PER_NUMERAL(bits)
-#endif
-
-#define DIGBASE(bits) ((vamp_t) pow(2.0, BITS_PER_NUMERAL2(bits)))
+#define DIGBASE(bits) ((vamp_t) pow(2.0, BITS_PER_NUMERAL(bits)))
 
 digits_t set_dig(fang_t number)
 {
@@ -100,7 +93,7 @@ bool cache_ovf_chk(vamp_t max)
 #endif
 
 	numeral_max = 2.0 * ceil(numeral_max / 2.0);
-	return (numeral_max >= (DIGBASE(ELEMENT_BITS) - 1) * (COMPARISON_BITS / ELEMENT_BITS));
+	return (numeral_max >= DIGBASE(ELEMENT_BITS) - 1);
 }
 
 #endif /* CACHE */

--- a/helsing/src/vampire/cache.c
+++ b/helsing/src/vampire/cache.c
@@ -7,7 +7,7 @@
 #include "configuration.h"
 #include "configuration_adv.h"
 
-#if CACHE
+#if ALG_CACHE
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>
@@ -15,7 +15,7 @@
 #include "cache.h"
 #endif
 
-#if CACHE
+#if ALG_CACHE
 
 #define BITS_PER_NUMERAL(bits) ((double)(bits))/(double)(BASE - 1)
 #define DIGBASE(bits) ((vamp_t) pow(2.0, BITS_PER_NUMERAL(bits)))
@@ -96,4 +96,4 @@ bool cache_ovf_chk(vamp_t max)
 	return (numeral_max >= DIGBASE(ELEMENT_BITS) - 1);
 }
 
-#endif /* CACHE */
+#endif /* ALG_CACHE */

--- a/helsing/src/vampire/cache.h
+++ b/helsing/src/vampire/cache.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
- * Copyright (c) 2021 Pierro Zachareas
+ * Copyright (c) 2021-2023 Pierro Zachareas
  */
 
 #ifndef HELSING_CACHE_H
@@ -65,7 +65,7 @@ static inline bool cache_ovf_chk(__attribute__((unused)) vamp_t max)
  * 	mult[0], mult[1], ... mult[n]
  * 	prod[0], prod[1], ... prod[m]
  *
- * The partitioning methods can be constant, semi-constant & non-constant:
+ * The partitioning methods can be constant, semi-constant & variable:
  * 	number:	n partitions
  * 	1) constant:
  * 		number[0] = number[1] = ... = number[n]
@@ -73,9 +73,9 @@ static inline bool cache_ovf_chk(__attribute__((unused)) vamp_t max)
  * 	2) semi-constant:
  * 		number[0] = number[1] = ... = number[n-1]
  *
- * 	3) non-constant
+ * 	3) variable
  *
- * The partitioning methods can be global, semi-global & non-global:
+ * The partitioning methods can be global, semi-global & local:
  * 	mult:	n partitions
  * 	prod:	m partitions
  * 	k = min(n, m)
@@ -92,7 +92,7 @@ static inline bool cache_ovf_chk(__attribute__((unused)) vamp_t max)
  * 		...
  * 		mult[k-1] = prod[k-1]
  *
- * 	3) non-global
+ * 	3) local
  *
  * Assuming that m,n > 1, all constant, semi-constant, global and semi-global
  * methods are loose-fit.
@@ -102,12 +102,12 @@ struct partdata_t
 {
 };
 
-struct partdata_const_t
+struct partdata_constant_t
 {
 	bool idx_n; // is index == n?
 };
 
-struct partdata_nonconst_t
+struct partdata_variable_t
 {
 	length_t index;
 };
@@ -122,18 +122,30 @@ struct partdata_global_t
 	length_t product_iterator;
 };
 
-struct partdata_nonglobal_t
+struct partdata_local_t
 {
 	length_t parts;
 	length_t length;
 	length_t iterator;
 };
 
+struct partdata_other_t
+{
+};
+
+struct partdata_all_t
+{
+	struct partdata_constant_t	constant;
+	struct partdata_variable_t	variable;
+	struct partdata_global_t  	global;
+	struct partdata_local_t   	local;
+	struct partdata_other_t   	other;
+};
+
 // Semi-Constant & Semi-Global
 __attribute__((const))
 length_t part_scsg_3(
-	struct partdata_t data,
-	struct partdata_const_t data_const,
+	struct partdata_constant_t data_const,
 	struct partdata_global_t data_glob);
 #endif /* ALG_CACHE */
 #endif /* HELSING_CACHE_H */

--- a/helsing/src/vampire/cache.h
+++ b/helsing/src/vampire/cache.h
@@ -42,4 +42,98 @@ static inline bool cache_ovf_chk(__attribute__((unused)) vamp_t max)
 	return false;
 }
 #endif /* ALG_CACHE */
+
+
+#if ALG_CACHE
+/*
+ * Partition
+ *
+ * We are tasked to partition numbers.
+ * For example if we wanted 3 partitions of the number 12345678, we could do two
+ * partitions of length 3 and one of length 2:
+ * 12345678 -> 123, 456, 78
+ * (8)         (3)  (3)  (2)
+ *
+ * We can partition the numbers for loose or exact fit
+ * 	1) loose fit, length(number) <= sum(partitions)
+ * 	2) exact fit, length(number) == sum(partitions)
+ *
+ * The rest of the code assumes loose, and works with either.
+ *
+ * In helsing, the numbers we partition are the multiplicand and the product.
+ * Let's partition them as such:
+ * 	mult[0], mult[1], ... mult[n]
+ * 	prod[0], prod[1], ... prod[m]
+ *
+ * The partitioning methods can be constant, semi-constant & non-constant:
+ * 	number:	n partitions
+ * 	1) constant:
+ * 		number[0] = number[1] = ... = number[n]
+ *
+ * 	2) semi-constant:
+ * 		number[0] = number[1] = ... = number[n-1]
+ *
+ * 	3) non-constant
+ *
+ * The partitioning methods can be global, semi-global & non-global:
+ * 	mult:	n partitions
+ * 	prod:	m partitions
+ * 	k = min(n, m)
+ *
+ * 	1) global:
+ * 		mult[0] = prod[0]
+ * 		mult[1] = prod[1]
+ * 		...
+ * 		mult[k] = prod[k]
+ *
+ * 	2) semi-global:
+ * 		mult[0] = prod[0]
+ * 		mult[1] = prod[1]
+ * 		...
+ * 		mult[k-1] = prod[k-1]
+ *
+ * 	3) non-global
+ *
+ * Assuming that m,n > 1, all constant, semi-constant, global and semi-global
+ * methods are loose-fit.
+ */
+
+struct partdata_t
+{
+};
+
+struct partdata_const_t
+{
+	bool idx_n; // is index == n?
+};
+
+struct partdata_nonconst_t
+{
+	length_t index;
+};
+
+struct partdata_global_t
+{
+	length_t multiplicand_parts;
+	length_t multiplicand_length;
+	length_t multiplicand_iterator;
+	length_t product_parts;
+	length_t product_length;
+	length_t product_iterator;
+};
+
+struct partdata_nonglobal_t
+{
+	length_t parts;
+	length_t length;
+	length_t iterator;
+};
+
+// Semi-Constant & Semi-Global
+__attribute__((const))
+length_t part_scsg_3(
+	struct partdata_t data,
+	struct partdata_const_t data_const,
+	struct partdata_global_t data_glob);
+#endif /* ALG_CACHE */
 #endif /* HELSING_CACHE_H */

--- a/helsing/src/vampire/cache.h
+++ b/helsing/src/vampire/cache.h
@@ -10,7 +10,7 @@
 #include "configuration_adv.h"
 #include <stdbool.h>
 
-#if CACHE
+#if ALG_CACHE
 struct cache
 {
 	digits_t *dig;
@@ -20,7 +20,7 @@ digits_t set_dig(fang_t number);
 void cache_new(struct cache **ptr, vamp_t min, vamp_t max);
 void cache_free(struct cache *ptr);
 bool cache_ovf_chk(vamp_t max);
-#else /* !CACHE */
+#else /* !ALG_CACHE */
 struct cache
 {
 };
@@ -41,5 +41,5 @@ static inline bool cache_ovf_chk(__attribute__((unused)) vamp_t max)
 {
 	return false;
 }
-#endif /* CACHE */
+#endif /* ALG_CACHE */
 #endif /* HELSING_CACHE_H */

--- a/helsing/src/vampire/vargs.c
+++ b/helsing/src/vampire/vargs.c
@@ -16,28 +16,6 @@
 #include "cache.h"
 #include "vargs.h"
 
-#if USE_PDEP
-#include <immintrin.h>
-#endif
-
-#if USE_PDEP
-static uint64_t get_pdep_mask()
-{
-	uint64_t single_element_mask = 1;
-	single_element_mask <<= (ACTIVE_BITS - 1) / (BASE - 1);
-	single_element_mask -= 1;
-	single_element_mask <<= 1;
-	single_element_mask += 1;
-
-	uint64_t ret = single_element_mask;
-	for (int i = 1; i < BASE - 1; i++) {
-		ret <<= (COMPARISON_BITS / (BASE - 1));
-		ret += single_element_mask;
-	}
-	return ret;
-}
-#endif
-
 static bool notrailingzero(fang_t x)
 {
 	return ((x % BASE) != 0);
@@ -160,9 +138,6 @@ void vampire(vamp_t min, vamp_t max, struct vargs *args, fang_t fmax)
 #if CACHE
 	fang_t power_a = pow_v(partition3(length(max)));
 	digits_t *dig = args->digptr->dig;
-#if USE_PDEP
-	const uint64_t pdep_mask = get_pdep_mask();
-#endif
 #endif
 
 	for (fang_t multiplier = fmax; multiplier >= min_sqrt && multiplier > 0; multiplier--) {
@@ -255,19 +230,7 @@ void vampire(vamp_t min, vamp_t max, struct vargs *args, fang_t fmax)
 			fang_t de2 = (product / power_a) / power_a;
 
 			for (; multiplicand <= multiplicand_max; multiplicand += BASE - 1) {
-#if USE_PDEP
-				uint64_t a = 0;
-				a += _pdep_u64(digd, pdep_mask);
-				a += _pdep_u64(dig[e0], pdep_mask);
-				a += _pdep_u64(dig[e1], pdep_mask);
-				uint64_t b = 0;
-				b += _pdep_u64(dig[de0], pdep_mask);
-				b += _pdep_u64(dig[de1], pdep_mask);
-				b += _pdep_u64(dig[de2], pdep_mask);
-				if (a == b)
-#else
 				if (digd + dig[e0] + dig[e1] == dig[de0] + dig[de1] + dig[de2])
-#endif
 					if (mult_zero || notrailingzero(multiplicand)) {
 						vargs_iterate_local_count(args);
 						vargs_print_results(product, multiplier, multiplicand);

--- a/helsing/src/vampire/vargs.c
+++ b/helsing/src/vampire/vargs.c
@@ -233,11 +233,25 @@ static inline void alg_cache_init(struct alg_cache *ptr, length_t lenmax, struct
 	ptr->digits_array = NULL;
 	if (cache != NULL)
 		ptr->digits_array = cache->dig;
-	
-	for (int i = 0; i < 2; i++)
-		ptr->multiplicand[i].mod = pow_v(partition3(lenmax));
-	for (int i = 0; i < 3; i++)
-		ptr->product[i].mod = pow_v(partition3(lenmax));
+
+	struct partdata_t data;
+	struct partdata_const_t data_const = {
+		.idx_n = false
+	};
+	length_t multiplicand_length =  div_roof(lenmax, 2);
+	struct partdata_global_t data_glob = {
+		.multiplicand_parts = 2,
+		.multiplicand_length = multiplicand_length,
+		.product_parts = 3,
+		.product_length = lenmax,
+		.multiplicand_iterator = length(BASE - 1),
+		.product_iterator = multiplicand_length + length(BASE - 1)
+	};
+
+	for (int i = 0; i < 2 - 1; i++)
+		ptr->multiplicand[i].mod = pow_v(part_scsg_3(data, data_const, data_glob));
+	for (int i = 0; i < 3 - 1; i++)
+		ptr->product[i].mod = pow_v(part_scsg_3(data, data_const, data_glob));
 }
 
 static void alg_cache_split(

--- a/helsing/src/vampire/vargs.c
+++ b/helsing/src/vampire/vargs.c
@@ -315,20 +315,23 @@ static inline void alg_cache_iterate(
 	struct num_part *arr,
 	int elements)
 {
-	// Splitting the code to multiple loops seems to help compilers optimize it
-
-	for (int i = 0; i < elements - 1; i++)
-		arr[i].number += arr[i].iterator;
+	/*
+	 * For whatever reason, writing the code like this makes it more
+	 * optimizable by gcc and clang, while retaining correctness.
+	 */
 
 	for (int i = 0; i < elements - 1; i++) {
-		arr[i].carry = 0;
-		if (arr[i].number >= arr[i].mod) {
+		arr[i].number += arr[i].iterator;
+		arr[i + 1].carry = 0;
+		if (arr[i].number >= arr[i].mod - arr[i].carry) {
 			arr[i].number -= arr[i].mod;
-			arr[i].carry = 1;
+			arr[i + 1].carry = 1;
 		}
 	}
-	for (int i = 0; i < elements - 1; i++)
-		arr[i + 1].number += arr[i].carry;
+	for (int i = 1; i < elements - 1; i++)
+		arr[i].number += arr[i].carry;
+	
+	arr[elements - 1].number += arr[elements - 1].carry;
 }
 
 static void alg_cache_iterate_all(struct alg_cache *ptr)

--- a/helsing/src/vampire/vargs.c
+++ b/helsing/src/vampire/vargs.c
@@ -234,12 +234,12 @@ static inline void alg_cache_init(struct alg_cache *ptr, length_t lenmax, struct
 	if (cache != NULL)
 		ptr->digits_array = cache->dig;
 
-	struct partdata_t data;
-	struct partdata_const_t data_const = {
+	struct partdata_all_t data;
+	struct partdata_constant_t data_constant = {
 		.idx_n = false
 	};
 	length_t multiplicand_length =  div_roof(lenmax, 2);
-	struct partdata_global_t data_glob = {
+	struct partdata_global_t data_global = {
 		.multiplicand_parts = 2,
 		.multiplicand_length = multiplicand_length,
 		.product_parts = 3,
@@ -249,9 +249,9 @@ static inline void alg_cache_init(struct alg_cache *ptr, length_t lenmax, struct
 	};
 
 	for (int i = 0; i < 2 - 1; i++)
-		ptr->multiplicand[i].mod = pow_v(part_scsg_3(data, data_const, data_glob));
+		ptr->multiplicand[i].mod = pow_v(part_scsg_3(data_constant, data_global));
 	for (int i = 0; i < 3 - 1; i++)
-		ptr->product[i].mod = pow_v(part_scsg_3(data, data_const, data_glob));
+		ptr->product[i].mod = pow_v(part_scsg_3(data_constant, data_global));
 }
 
 static void alg_cache_split(

--- a/helsing/src/vampire/vargs.c
+++ b/helsing/src/vampire/vargs.c
@@ -129,16 +129,193 @@ void vargs_reset(struct vargs *args)
 	args->result = NULL;
 }
 
+#if ALG_NORMAL // when false we use the empty functions in vargs.h
+
+static void alg_normal_set(fang_t multiplier, length_t (*mult_array)[BASE])
+{
+	for (digit_t i = 0; i < BASE; i++)
+		(*mult_array)[i] = 0;
+
+	for (fang_t i = multiplier; i > 0; i /= BASE)
+		(*mult_array)[i % BASE] += 1;
+}
+
+static void alg_normal_check(
+	length_t mult_array[BASE],
+	fang_t multiplicand,
+	vamp_t product,
+	int *result)
+{
+	uint16_t product_array[BASE] = {0};
+	for (vamp_t p = product; p > 0; p /= BASE)
+		product_array[p % BASE] += 1;
+
+	for (digit_t i = 0; i < BASE; i++)
+		if (product_array[i] < mult_array[i])
+			goto out;
+
+	digit_t temp;
+	for (fang_t m = multiplicand; m > 0; m /= BASE) {
+		temp = m % BASE;
+		if (product_array[temp] == 0)
+			goto out;
+		else
+			product_array[temp]--;
+	}
+	for (digit_t i = 0; i < (BASE - 1); i++)
+		if (product_array[i] != mult_array[i])
+			goto out;
+
+	(*result) += 1;
+out:
+	return;
+}
+
+#endif /* ALG_NORMAL */
+
+#if ALG_CACHE // when false we use the empty functions in vargs.h
+
+/*
+ * We could just allocate the entire dig[] array, and then do:
+ *
+ * 	for (; multiplicand <= multiplicand_max; multiplicand += BASE - 1) {
+ * 		if (dig[multiplier] + dig[multiplicand] == dig[product]) {
+ * 			...
+ * 		}
+ * 		product += product_iterator;
+ *		multiplicand += BASE-1;
+ *	}
+ *
+ * This would work just fine.
+ * The only problem is that the array would be way too
+ * big to fit in most l3 caches and we would waste a
+ * majority of time loading data from memory.
+ *
+ * If we 'partition' the numbers (123 -> 12, 3), we can
+ * make the array much smaller.
+ *
+ * Of course, 'partitioning' requires some computation,
+ * but we are already waiting for memory load
+ * operations, and we might as well put the wasted
+ * cycles to good use.
+ *
+ * We 'partition' like this:
+ * 	multiplier: multiplier[0]
+ * 	multiplicand: multiplicand[0], multiplicand[1]
+ *
+ * 	product:          product[0],   product[1],   product[2]
+ * 	product iterator: product_iterator[0], product_iterator[1], product_iterator[2]
+ *
+ * Because it seems to perform pretty well.
+ */
+
+struct alg_cache
+{
+	fang_t mod;
+	digits_t *digits_array;
+	digits_t dig_multiplier;	// doesn't change when we iterate
+	fang_t multiplicand[2];
+	// multiplicand iterator is BASE - 1
+	fang_t product[3];
+	fang_t product_iterator[3];
+};
+
+static void alg_cache_init(struct alg_cache *ptr, fang_t mod, struct cache *cache)
+{
+	OPTIONAL_ASSERT(ptr != NULL);
+	ptr->mod = mod;
+	ptr->digits_array = cache->dig;
+}
+
+static void alg_cache_split(vamp_t number, fang_t mod, fang_t *arr, int n)
+{
+	for (int i = 0; i < n - 1; i++) {
+		arr[i] = number % mod;
+		number /= mod;
+	}
+	arr[n - 1] = number; // number >= number % mod
+}
+
+static void alg_cache_set(
+	struct alg_cache *ptr,
+	fang_t multiplier,
+	fang_t multiplicand,
+	vamp_t product,
+	vamp_t product_iterator)
+{
+	/*
+	 * dig_multiplier = digits_array[multiplier];
+	 * Each dig_multiplier is calculated and accessed only once, we don't need to store them in memory.
+	 * We can calculate dig_multiplier on the spot and make the dig array 10 times smaller.
+	 */
+
+	ptr->dig_multiplier = set_dig(multiplier);
+	alg_cache_split(multiplicand, ptr->mod, ptr->multiplicand, 2);
+	alg_cache_split(product, ptr->mod, ptr->product, 3);
+
+	/*
+	 * We can improve the runtime even further by removing product_iterator[2].
+	 * If product_iterator[2] is always 0, we don't need it.
+	 *
+	 * product_iterator[2] = (product_iterator / power_a) / power_a
+	 *
+	 * product_iterator[2] has 0 digits, product_iterator has n+1, and we are going to solve for power_a:
+	 *
+	 * 0 >= (n+1 - x) - x
+	 * x >= n+1 - x
+	 */
+
+	alg_cache_split(product_iterator, ptr->mod, ptr->product_iterator, 3);
+	OPTIONAL_ASSERT(ptr->product_iterator[2] == 0);
+}
+
+static void alg_cache_check(struct alg_cache *ptr, int *result)
+{
+	const digits_t *digits_array = ptr->digits_array;
+	if (
+		ptr->dig_multiplier
+		+ digits_array[ptr->multiplicand[0]]
+		+ digits_array[ptr->multiplicand[1]]
+		==
+		digits_array[ptr->product[0]]
+		+ digits_array[ptr->product[1]]
+		+ digits_array[ptr->product[2]]
+	)
+		(*result) += 1;
+}
+
+static void alg_cache_iterate(
+	fang_t mod,
+	fang_t arr[2],
+	fang_t iterator)
+{
+	arr[0] += iterator;
+	if (arr[0] >= mod) {
+		arr[0] -= mod;
+		arr[1] += 1;
+	}
+}
+
+static void alg_cache_iterate_all(struct alg_cache *ptr)
+{
+	alg_cache_iterate(ptr->mod, ptr->multiplicand, BASE - 1);
+	alg_cache_iterate(ptr->mod, ptr->product, ptr->product_iterator[0]);
+	alg_cache_iterate(ptr->mod, &(ptr->product[1]), ptr->product_iterator[1]);
+}
+
+#endif /* ALG_CACHE */
+
+
 void vampire(vamp_t min, vamp_t max, struct vargs *args, fang_t fmax)
 {
 	struct llnode *ll = NULL;
 	fang_t min_sqrt = sqrtv_roof(min);
 	fang_t max_sqrt = sqrtv_floor(max);
 
-#if CACHE
-	fang_t power_a = pow_v(partition3(length(max)));
-	digits_t *dig = args->digptr->dig;
-#endif
+	struct alg_cache ag_data;
+	alg_cache_init(&ag_data, pow_v(partition3(length(max))), args->digptr);
+
+	length_t mult_array[BASE];
 
 	for (fang_t multiplier = fmax; multiplier >= min_sqrt && multiplier > 0; multiplier--) {
 		if (disqualify_mult(multiplier))
@@ -157,140 +334,33 @@ void vampire(vamp_t min, vamp_t max, struct vargs *args, fang_t fmax)
 		while (multiplicand <= multiplicand_max && congruence_check(multiplier, multiplicand))
 			multiplicand++;
 
-		if (multiplicand <= multiplicand_max) {
-			/*
-			 * If multiplier has n digits, then product_iterator has at most n+1 digits.
-			 */
-			vamp_t product_iterator = multiplier;
-			product_iterator *= BASE - 1; // <= (BASE-1) * (2^32)
-			vamp_t product = multiplier;
-			product *= multiplicand; // avoid overflow
+		if (multiplicand > multiplicand_max)
+			continue;
+		/*
+		 * If multiplier has n digits, then product_iterator has at most n+1 digits.
+		 */
+		vamp_t product_iterator = multiplier;
+		product_iterator *= BASE - 1; // <= (BASE-1) * (2^32)
+		vamp_t product = multiplier;
+		product *= multiplicand; // avoid overflow
 
-#if CACHE
-			/*
-			 * We could just allocate the entire dig[] array, and then do:
-			 *
-			 * 	for (; multiplicand <= multiplicand_max; multiplicand += BASE - 1) {
-			 * 		if (dig[multiplier] + dig[multiplicand] == dig[product]) {
-			 * 			...
-			 * 		}
-			 * 		product += product_iterator;
-			 *		multiplicand += BASE-1;
-			 *	}
-			 *
-			 * This would work just fine.
-			 * The only problem is that the array would be way too
-			 * big to fit in most l3 caches and we would waste a
-			 * majority of time loading data from memory.
-			 *
-			 * If we 'partition' the numbers (123 -> 12, 3), we can
-			 * make the array much smaller.
-			 *
-			 * Of course, 'partitioning' requires some computation,
-			 * but we are already waiting for memory load
-			 * operations, and we might as well put the wasted
-			 * cycles to good use.
-			 *
-			 * I chose to 'partition' like this:
-			 * 	product:          de0,   de1,   de2
-			 * 	product iterator: step0, step1, step2
-			 *
-			 * 	multiplicand: e0, e1
-			 * Because it performs the best on all of my cpus.
-			 */
+		alg_cache_set(&ag_data, multiplier, multiplicand, product, product_iterator);
 
-			/*
-			 * We can improve the runtime even further by removing step2.
-			 * If step2 is always 0, we don't need it.
-			 *
-			 * step2 = (product_iterator / power_a) / power_a
-			 *
-			 * step2 has 0 digits, product_iterator has n+1, and we are going to solve for power_a:
-			 *
-			 * 0 >= (n+1 - x) - x
-			 * x >= n+1 - x
-			 */
+		alg_normal_set(multiplier, &mult_array);
 
-			fang_t step0 = product_iterator % power_a;
-			fang_t step1 = product_iterator / power_a;
+		for (; multiplicand <= multiplicand_max; multiplicand += BASE - 1) {
+			int result = 0;
 
-			/*
-			 * digd = dig[multiplier];
-			 * Each digd is calculated and accessed only once, we don't need to store them in memory.
-			 * We can calculate digd on the spot and make the dig array 10 times smaller.
-			 */
+			alg_normal_check(mult_array, multiplicand, product, &result);
+			alg_cache_check(&ag_data, &result);
 
-			digits_t digd = set_dig(multiplier);
-
-			fang_t e0 = multiplicand % power_a;
-			fang_t e1 = multiplicand / power_a;
-
-			fang_t de0 = product % power_a;
-			fang_t de1 = (product / power_a) % power_a;
-			fang_t de2 = (product / power_a) / power_a;
-
-			for (; multiplicand <= multiplicand_max; multiplicand += BASE - 1) {
-				if (digd + dig[e0] + dig[e1] == dig[de0] + dig[de1] + dig[de2])
-					if (mult_zero || notrailingzero(multiplicand)) {
-						vargs_iterate_local_count(args);
-						vargs_print_results(product, multiplier, multiplicand);
-						llnode_add(&(ll), product);
-					}
-				product += product_iterator;
-				e0 += BASE - 1;
-				if (e0 >= power_a) {
-					e0 -= power_a;
-					e1 += 1;
-				}
-				de0 += step0;
-				if (de0 >= power_a) {
-					de0 -= power_a;
-					de1 += 1;
-				}
-				de1 += step1;
-				if (de1 >= power_a) {
-					de1 -= power_a;
-					de2 += 1;
-				}
+			if (result && (mult_zero || notrailingzero(multiplicand))) {
+				vargs_iterate_local_count(args);
+				vargs_print_results(product, multiplier, multiplicand);
+				llnode_add(&(ll), product);
 			}
-
-#else /* CACHE */
-
-			length_t mult_array[BASE] = {0};
-			for (fang_t i = multiplier; i > 0; i /= BASE)
-				mult_array[i % BASE] += 1;
-
-			for (; multiplicand <= multiplicand_max; multiplicand += BASE - 1) {
-				uint16_t product_array[BASE] = {0};
-				for (vamp_t p = product; p > 0; p /= BASE)
-					product_array[p % BASE] += 1;
-
-				for (digit_t i = 0; i < BASE; i++)
-					if (product_array[i] < mult_array[i])
-						goto vampire_exit;
-
-				digit_t temp;
-				for (fang_t m = multiplicand; m > 0; m /= BASE) {
-					temp = m % BASE;
-					if (product_array[temp] == 0)
-						goto vampire_exit;
-					else
-						product_array[temp]--;
-				}
-				for (digit_t i = 0; i < (BASE - 1); i++)
-					if (product_array[i] != mult_array[i])
-						goto vampire_exit;
-
-				if (mult_zero || notrailingzero(multiplicand)) {
-					vargs_iterate_local_count(args);
-					vargs_print_results(product, multiplier, multiplicand);
-					llnode_add(&(ll), product);
-				}
-vampire_exit:
-				product += product_iterator;
-			}
-
-#endif /* CACHE */
+			alg_cache_iterate_all(&ag_data);
+			product += product_iterator;
 		}
 	}
 	array_new(&(args->result), ll, &(args->local_count));

--- a/helsing/src/vampire/vargs.c
+++ b/helsing/src/vampire/vargs.c
@@ -276,12 +276,12 @@ static void alg_cache_set(
 	 * We can improve the runtime even further by removing product_iterator[2].
 	 * If product_iterator[2] is always 0, we don't need it.
 	 *
-	 * product_iterator[2] = (product_iterator / power_a) / power_a
+	 * product_iterator[2] = (product_iterator / (x1^BASE)) / (x2^BASE)
 	 *
 	 * product_iterator[2] has 0 digits, product_iterator has n+1, and we are going to solve for power_a:
 	 *
-	 * 0 >= (n+1 - x) - x
-	 * x >= n+1 - x
+	 * 0 >= (n+1 - x1) - x2
+	 * x1 + x2 >= n+1
 	 */
 
 	if (ptr->multiplicand[0].iterator != BASE-1)

--- a/helsing/src/vampire/vargs.h
+++ b/helsing/src/vampire/vargs.h
@@ -56,4 +56,48 @@ static inline void vargs_print_results(
 {
 }
 #endif /* DUMP_RESULTS */
+
+#if !(ALG_NORMAL)
+static inline void alg_normal_set(
+	__attribute__((unused)) fang_t multiplier,
+	__attribute__((unused)) length_t (*mult_array)[BASE])
+{
+}
+static inline void alg_normal_check(
+	__attribute__((unused)) length_t mult_array[BASE],
+	__attribute__((unused)) fang_t multiplicand,
+	__attribute__((unused)) vamp_t product,
+	__attribute__((unused)) int *result)
+{
+}
+#endif /* !ALG_NORMAL */
+
+#if !(ALG_CACHE)
+struct alg_cache
+{
+};
+static inline void alg_cache_init(
+	__attribute__((unused)) struct alg_cache *ptr,
+	__attribute__((unused)) fang_t mod,
+	__attribute__((unused)) struct cache *cache)
+{
+}
+static inline void alg_cache_set(
+	__attribute__((unused)) struct alg_cache *ptr,
+	__attribute__((unused)) fang_t multiplier,
+	__attribute__((unused)) fang_t multiplicand,
+	__attribute__((unused)) vamp_t product,
+	__attribute__((unused)) vamp_t product_iterator)
+{
+}
+static inline void alg_cache_check(
+	__attribute__((unused)) struct alg_cache *ptr,
+	__attribute__((unused)) int *result)
+{
+}
+static inline void alg_cache_iterate_all(__attribute__((unused)) struct alg_cache *ptr)
+{
+}
+#endif /* !ALG_CACHE */
+
 #endif /* HELSING_VARGS_H */


### PR DESCRIPTION
Removed
1. `PDEP` &`DEDICATED_BITFIELDS`  Weren't helping with performance

Changed:
1. Simplified `vampire()` by moving code to algorithm specific functions
2. re-wrote the cache algorith using functions and loops to allow reconfiguration with future macros
3. re-wrote cache partitioning in a way that allows new partitioning functions to be added
4. Made OpenSSL optional for cmake

Added:
1. `ALG_NORMAL` Toggles the normal algorithm
2. `ALG_CACHE` Toggles the cache algorithm
3. `sort` in the Makefile for consistent compilation